### PR TITLE
Reference python3 instead of python in hashbang

### DIFF
--- a/internal/toolchain/toolchain.bzl
+++ b/internal/toolchain/toolchain.bzl
@@ -115,7 +115,7 @@ def _legacy_install(repository_ctx):
         "bin/strip_dependencies",
         repository_ctx.attr._strip_dependencies_py_tmpl,
         substitutions = {
-            "{HASH_BANG}": "/usr/bin/env python",
+            "{HASH_BANG}": "/usr/bin/env python3",
         },
         executable = True,
     )


### PR DESCRIPTION
This fixes a build error on Ubuntu 20.04:

```
ERROR: /workspace/WORKSPACE:41:15: fetching poetry_export rule //external:py_deps_export: Traceback (most recent call last):
        File "/workspace/out/external/rules_python_poetry/internal/export.bzl", line 19, column 17, in _poetry_export_impl
                fail("Poetry strip dependencies failed:\n%s\n%s" % (result.stdout, result.stderr))
```

Not all distros have `python` pointing to `python3` by default yet. It's possible to resolve the issue by installing `python-is-python3` but IMO explicitly specifying the version is better since it avoids this build error without needing to modify the host machine.

A future improvement could be to allow specifying a Bazel target which points to the Python target to use.